### PR TITLE
Return cached data if errors occur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "yield-backend",
       "version": "0.0.1",
       "dependencies": {
-        "@moonwell-fi/moonwell-sdk": "^0.7.2"
+        "@moonwell-fi/moonwell-sdk": "^0.9.15"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.5.2",
@@ -19,10 +19,23 @@
         "wrangler": "^3.103.2"
       }
     },
+    "node_modules/@across-protocol/app-sdk": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@across-protocol/app-sdk/-/app-sdk-0.2.3.tgz",
+      "integrity": "sha512-fxKYy0fKS5jbcq66gKtRYo1TWFvzeAYYPNBubrssCu7ECKFgOTT5dolPUj4Y+UwAJtVItFMvvkxO4OvMGbK7Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "viem": "^2.20.1"
+      }
+    },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -98,6 +111,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@biconomy/abstractjs": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@biconomy/abstractjs/-/abstractjs-1.1.19.tgz",
+      "integrity": "sha512-J9tdC+fnswqaMdEjQkS5W5+QzpercIW9INX/oRMw6uuxsc6JlApMk3wA8b8iaNLY9FMZ3C3NZtZLDZ1SSCbaKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@metamask/delegation-toolkit": "^0.11.0",
+        "@rhinestone/module-sdk": "0.4.0",
+        "typescript": "^5.8.2",
+        "viem": "^2.26.2"
+      }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.3.4",
@@ -432,17 +457,77 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@moonwell-fi/moonwell-sdk": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@moonwell-fi/moonwell-sdk/-/moonwell-sdk-0.7.2.tgz",
-      "integrity": "sha512-XOG+QcLO3AjmFM7TtkHLhiaIZajUAYjx+rUb/E0Mq8oy/qrqU4n1ss38O6iRid7QZtyv1ojamF/oiiQaXliwBg==",
+    "node_modules/@metamask/delegation-abis": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/delegation-abis/-/delegation-abis-0.11.0.tgz",
+      "integrity": "sha512-tnNGFDLQ5jfgPhHJaT5JwvF759nja1iGAG00REbk1Ufir+TxjxTmF8L9MbJifZmUh4fnyqV4Ik6NAOYVNBPVBg==",
+      "license": "(MIT-0 OR Apache-2.0)",
+      "peer": true,
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/delegation-deployments": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/delegation-deployments/-/delegation-deployments-0.11.0.tgz",
+      "integrity": "sha512-RfeMr1Ct0givG7oOy1unwdb5lGttq9pape4OGz2mk8quG0KDqDi7cw3fzYc7wz9xFDZ2YrFanYRacaLTlqWS8g==",
+      "license": "(MIT-0 OR Apache-2.0)",
+      "peer": true,
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/delegation-toolkit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/delegation-toolkit/-/delegation-toolkit-0.11.0.tgz",
+      "integrity": "sha512-KQybftUahuPPjN842ejmVaJWg2rzHpSpvd+b6qtiOBypzJs7cgw1/f8QalHLugS1eyicEYLXwvRxjjufiG4wbg==",
+      "deprecated": "Renamed to @metamask/smart-accounts-kit",
+      "license": "(MIT-0 OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
+        "@metamask/delegation-utils": "^0.11.0",
+        "webauthn-p256": "^0.0.5"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "viem": ">=2.18.2 <3.0.0"
+      }
+    },
+    "node_modules/@metamask/delegation-utils": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/delegation-utils/-/delegation-utils-0.11.0.tgz",
+      "integrity": "sha512-eg8icyDtbzwER/G3VvaiVUNiNr9GXxJXQMcFRbhm9tTMqWXpphYXk9edSungRF+QqYmXIytRiR2ChSHp0uNtew==",
+      "license": "(MIT-0 OR Apache-2.0)",
+      "peer": true,
+      "dependencies": {
+        "@metamask/delegation-abis": "^0.11.0",
+        "@metamask/delegation-deployments": "^0.11.0",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "viem": ">=2.18.2 <3.0.0"
+      }
+    },
+    "node_modules/@moonwell-fi/moonwell-sdk": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/@moonwell-fi/moonwell-sdk/-/moonwell-sdk-0.9.15.tgz",
+      "integrity": "sha512-LHn9e/LH8mGCZcxhNXJDWNrK2RuLTWAc5ZNcj7SrO03Y4gLLaKiR0i99DA7eT/bw9ZNq19XrZlwlmYsF4Opg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@across-protocol/app-sdk": "^0.2.3",
+        "@biconomy/abstractjs": "^1.0.18",
+        "@rhinestone/module-sdk": "0.2.7",
         "@types/lodash": "^4.17.9",
         "@types/node": "^22.13.10",
         "axios": "^1.7.7",
         "dayjs": "^1.11.13",
         "lodash": "^4.17.21",
-        "viem": "^2.23.6"
+        "viem": "^2.26.2"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -453,12 +538,25 @@
         }
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -468,9 +566,10 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -488,6 +587,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rhinestone/module-sdk": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@rhinestone/module-sdk/-/module-sdk-0.2.7.tgz",
+      "integrity": "sha512-clZVB6erRdkDpaYodFsRVhU+Sj4immytLWK76jL9MsjnBg9vDEEMK3izUpsGax6YLDI0/QTrn0sW0qyhLz8fBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "solady": "^0.0.235",
+        "tslib": "^2.7.0"
+      },
+      "peerDependencies": {
+        "viem": "^2.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.27.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.2.tgz",
@@ -502,33 +614,36 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.8.1",
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.4"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -709,15 +824,16 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
+        "zod": "^3.22.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -815,6 +931,27 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/birpc": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
@@ -837,6 +974,31 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/cac": {
@@ -1099,7 +1261,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -1291,6 +1454,27 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -1334,15 +1518,16 @@
       "dev": true
     },
     "node_modules/isows": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -1688,22 +1873,24 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
-      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.10.5.tgz",
+      "integrity": "sha512-mXJRiZswmX46abrzNkJpTN9sPJ/Rhevsp5Dfg0z80D55aoLNmEV4oN+/+feSNW593c2CnHavMqSVBanpJ0lUkQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -2017,6 +2204,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/solady": {
+      "version": "0.0.235",
+      "resolved": "https://registry.npmjs.org/solady/-/solady-0.0.235.tgz",
+      "integrity": "sha512-JUEXLDG7ag3HmqUnrDG7ilhafH6R9bFPpwV63O2kH4UbnS2+gRGEOqqy4k01O7tHjo3MWkDD0cpG+UY9pjy/fQ==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2256,14 +2449,13 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "devOptional": true,
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2310,24 +2502,25 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.23.14",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.14.tgz",
-      "integrity": "sha512-ol8UKYT418u+7Lg83Ut7WJe7iOn1daGAqaofCoPe5z7eGR/XCu3ydja7eL7Z5ffwp6r0RoXeWkpun78UYhKygA==",
+      "version": "2.43.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.43.1.tgz",
+      "integrity": "sha512-S33pBNlRvOlVv4+L94Z8ydCMDB1j0cuHFUvaC28i6OTxw3uY1P4M3h1YDFK8YC1H9/lIbeBTTvCRhi0FqU/2iw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@scure/bip32": "1.6.2",
-        "@scure/bip39": "1.5.4",
-        "abitype": "1.0.8",
-        "isows": "1.0.6",
-        "ox": "0.6.9",
-        "ws": "8.18.1"
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.10.5",
+        "ws": "8.18.3"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -2598,6 +2791,23 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/webauthn-p256": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.5.tgz",
+      "integrity": "sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0"
       }
     },
     "node_modules/which": {
@@ -2904,9 +3114,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "wrangler": "^3.103.2"
   },
   "dependencies": {
-    "@moonwell-fi/moonwell-sdk": "^0.7.2"
+    "@moonwell-fi/moonwell-sdk": "^0.9.15"
   }
 }

--- a/plans/stale-cache-fallback.md
+++ b/plans/stale-cache-fallback.md
@@ -1,0 +1,142 @@
+# Stale Cache Fallback Architecture Plan
+
+## Overview
+Modify the Cloudflare Worker to return stale cached data when sub-requests to the moonwell-sdk fail, instead of returning an error. This provides better resilience and availability for API consumers.
+
+## Current Behavior
+```
+1. Check R2 bucket for cached data
+2. If cache is missing OR older than 180 seconds → Fetch fresh data from SDK
+3. If cache exists and is fresh (< 180s) → Return cached data
+4. No error handling for SDK failures
+```
+
+## New Behavior
+```
+1. Check R2 bucket for cached data
+2. Store reference to any existing cached data (regardless of age)
+3. If cache is missing OR older than 180 seconds:
+   a. Try to fetch fresh data from SDK
+   b. On success → Cache and return fresh data
+   c. On failure:
+      - If stale cache exists → Return stale cached data with logging
+      - If no cache exists → Return error response
+4. If cache exists and is fresh (< 180s) → Return cached data
+```
+
+## Implementation Strategy
+
+### Flow Diagram
+```mermaid
+graph TD
+    A[Request received] --> B[Check R2 cache]
+    B --> C{Cache exists?}
+    C -->|No| D[Store cache = null]
+    C -->|Yes| E[Store cache reference]
+    D --> F{Need fresh data?}
+    E --> G{Cache age > 180s?}
+    G -->|No| H[Return cached data - FRESH]
+    G -->|Yes| F
+    F --> I[Try fetch from SDK]
+    I --> J{Fetch successful?}
+    J -->|Yes| K[Update R2 cache]
+    K --> L[Return fresh data]
+    J -->|No| M{Stale cache exists?}
+    M -->|Yes| N[Return stale data - FALLBACK]
+    M -->|No| O[Return error response]
+```
+
+### Code Changes Required
+
+#### 1. Store Cache Reference Early
+```typescript
+// Before checking cache age, store the object reference
+const object = await env.MY_BUCKET.get(uri);
+const cacheExists = object !== null;
+const cacheIsStale = cacheExists && object.uploaded.getTime() < (Date.now() - 180000);
+```
+
+#### 2. Wrap SDK Calls in Try-Catch
+```typescript
+if (!cacheExists || cacheIsStale) {
+  try {
+    // Existing fetch logic
+    const moonwellClient = createMoonwellClient(...);
+    const markets = await moonwellClient.getMarkets(...);
+    const vaults = await moonwellClient.getMorphoVaults(...);
+    // ... serialize and cache
+    return respond(output);
+  } catch (error) {
+    // Error handling logic here
+  }
+}
+```
+
+#### 3. Fallback to Stale Cache on Error
+```typescript
+catch (error) {
+  console.error('SDK request failed:', error);
+  
+  if (cacheExists) {
+    console.log('Returning stale cached data as fallback');
+    const data = await object.json() as { data: Record<string, unknown>, uploaded: string };
+    console.log('Stale cache age:', Date.now() - new Date(data.uploaded).getTime(), 'ms');
+    return respond(data.data);
+  }
+  
+  console.error('No cached data available for fallback');
+  return respond({ error: 'Service temporarily unavailable' }, 503);
+}
+```
+
+#### 4. Enhanced Logging
+Add distinct console.log messages for:
+- `'Cache hit - returning fresh cached data'` (within 180s TTL)
+- `'Cache miss or stale - fetching fresh data'` (attempting SDK call)
+- `'SDK request failed - returning stale cached data as fallback'` (error + stale cache)
+- `'SDK request failed - no cached data available'` (error + no cache)
+
+## Benefits
+
+### Improved Availability
+- API remains available even when backend SDK requests fail
+- Stale data is better than no data for most use cases
+
+### Graceful Degradation
+- Normal operation: Fresh data with 180s cache
+- Degraded operation: Stale data when upstream fails
+- Complete failure: Error only when no cache exists at all
+
+### Transparent Operation
+- Enhanced logging makes it clear what data source is being used
+- Monitoring can track fallback frequency to detect upstream issues
+
+## Testing Scenarios
+
+1. **Normal operation**: Cache miss → successful fetch → cache and return
+2. **Normal operation**: Cache hit (< 180s) → return cached data
+3. **Stale cache fallback**: Cache stale + SDK failure → return stale cache
+4. **Complete failure**: No cache + SDK failure → return 503 error
+5. **Recovery**: Stale cache being used → SDK recovers → fresh data returned
+
+## Rollback Plan
+
+If issues arise, the change is isolated to the [`fetch()`](src/index.ts:36) function. Reverting the try-catch block restores original behavior where errors propagate immediately.
+
+## Considerations
+
+### Cache Timestamp
+The cached object includes an `uploaded` timestamp. When returning stale data on error, we should log how old the cache is for monitoring purposes.
+
+### Error Types
+Different SDK errors (network timeout, rate limit, invalid response) all trigger the same fallback behavior. This is intentional for simplicity and reliability.
+
+### Maximum Stale Age
+Currently no limit on how old the stale cache can be. If desired, could add a maximum stale age (e.g., 1 hour) beyond which we return an error even if cache exists.
+
+## Next Steps
+
+Once this plan is approved, the implementation can proceed in Code mode to:
+1. Modify [`src/index.ts`](src/index.ts) with the new error handling logic
+2. Test the changes locally with wrangler dev
+3. Deploy to Cloudflare Workers

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,59 +41,78 @@ export default {
     const uri = 'market-vault-yields.json'
     const object = await env.MY_BUCKET.get(uri)
 
-    if (
-      (object === null) ||
-      (object.uploaded.getTime() < (Date.now()) - (180000))
-    ) { // Cached object is not found or older than 180 seconds/3 minutes
-      console.log('Cache miss, fetching new data...')
-      const moonwellClient = createMoonwellClient({
-        networks: {
-          base: {
-            rpcUrls: [env.BASE_RPC_URL],
+    const cacheExists = object !== null;
+    const cacheIsStale = cacheExists && object.uploaded.getTime() < (Date.now() - 180000);
+
+    if (!cacheExists || cacheIsStale) {
+      // Cache is missing or older than 180 seconds/3 minutes
+      console.log('Cache miss or stale - attempting to fetch fresh data...')
+      
+      try {
+        const moonwellClient = createMoonwellClient({
+          networks: {
+            base: {
+              rpcUrls: [env.BASE_RPC_URL],
+            },
           },
-        },
-      });
+        });
 
-      const markets = await moonwellClient.getMarkets({chainId: 8453});
-      const vaults = await moonwellClient.getMorphoVaults({includeRewards: true});
+        const markets = await moonwellClient.getMarkets({chainId: 8453});
+        const vaults = await moonwellClient.getMorphoVaults({includeRewards: true});
 
-      // Create the output object
-      const output: {
-        markets: Record<string, any>;
-        vaults: Record<string, any>;
-      } = {
-        markets: {},
-        vaults: {}
-      };
+        // Create the output object
+        const output: {
+          markets: Record<string, any>;
+          vaults: Record<string, any>;
+        } = {
+          markets: {},
+          vaults: {}
+        };
 
-      // Serialize markets
-      markets.forEach(market => {
-        const serializedMarket = serializeMarket(market);
-        if (serializedMarket && serializedMarket.marketKey) {
-          output.markets[serializedMarket.marketKey] = serializedMarket;
+        // Serialize markets
+        markets.forEach(market => {
+          const serializedMarket = serializeMarket(market);
+          if (serializedMarket && serializedMarket.marketKey) {
+            output.markets[serializedMarket.marketKey] = serializedMarket;
+          }
+        });
+
+        // Serialize vaults
+        vaults.forEach(vault => {
+          const serializedVault = serializeVault(vault);
+          if (serializedVault && serializedVault.vaultKey) {
+            output.vaults[serializedVault.vaultKey] = serializedVault;
+          }
+        });
+
+        console.log('Successfully fetched fresh data');
+
+        // Cache the data
+        await env.MY_BUCKET.put(uri, JSON.stringify({
+          uploaded: new Date(),
+          data: output
+        }));
+
+        return respond(output);
+      } catch (error) {
+        // SDK request failed - try to return stale cached data as fallback
+        console.error('SDK request failed:', error);
+        
+        if (cacheExists) {
+          const data = await object.json() as { data: Record<string, unknown>, uploaded: string };
+          const cacheAge = Date.now() - new Date(data.uploaded).getTime();
+          console.log(`Returning stale cached data as fallback (age: ${Math.round(cacheAge / 1000)}s)`);
+          return respond(data.data);
         }
-      });
-
-      // Serialize vaults
-      vaults.forEach(vault => {
-        const serializedVault = serializeVault(vault);
-        if (serializedVault && serializedVault.vaultKey) {
-          output.vaults[serializedVault.vaultKey] = serializedVault;
-        }
-      });
-
-      console.log('Fetched data:', output);
-
-      // Cache the data
-      await env.MY_BUCKET.put(uri, JSON.stringify({
-        uploaded: new Date(),
-        data: output
-      }));
-
-      return respond(output);
+        
+        // No cached data available at all
+        console.error('No cached data available for fallback');
+        return respond({ error: 'Service temporarily unavailable', message: 'Unable to fetch data and no cached data available' }, 503);
+      }
     }
 
-    // Return cached data
+    // Return fresh cached data (within 180s TTL)
+    console.log('Cache hit - returning fresh cached data');
     const data = await object.json() as { data: Record<string, unknown> };
     return respond(data.data);
   },


### PR DESCRIPTION
This pull request introduces a stale cache fallback mechanism to the Cloudflare Worker, improving API resilience by serving stale cached data when backend SDK requests fail. It also updates the `moonwell-sdk` dependency and adds comprehensive documentation for the new behavior. The most important changes are grouped below:

**Stale Cache Fallback Implementation:**

* Updated the cache handling logic in `src/index.ts` to serve stale cached data when SDK requests fail, instead of returning an error. Now, if a fresh cache is unavailable and the SDK call fails, the worker will return the most recent cached data if available, improving availability. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L44-R51) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R97-R115)
* Enhanced logging throughout the cache and fetch flow, including logs for cache hits, cache misses, SDK failures, and stale cache fallback scenarios, making system behavior more transparent and easier to monitor. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L85-R88) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R97-R115)

**Documentation and Planning:**

* Added a detailed architecture plan in `plans/stale-cache-fallback.md` describing the new fallback strategy, implementation steps, benefits, testing scenarios, and rollback plan.

**Dependency Update:**

* Upgraded the `@moonwell-fi/moonwell-sdk` dependency from version `0.7.2` to `0.9.15` in `package.json` to ensure compatibility with the latest features and bug fixes.