### PR TITLE
MOO-391: Include WELL staking rewards in yield API rewardsApy/totalApy

### DIFF
--- a/src/serializers/vault.ts
+++ b/src/serializers/vault.ts
@@ -1,4 +1,4 @@
-import type { MorphoVault, MorphoVaultMarket, MorphoReward } from '@moonwell-fi/moonwell-sdk';
+import type { MorphoVault, MorphoVaultMarket, MorphoReward, MorphoStakingReward } from '@moonwell-fi/moonwell-sdk';
 import { serializeAmount } from './amount';
 import { serializeToken, type SerializedToken } from './token';
 
@@ -59,6 +59,35 @@ export const serializeVault = (vault: Partial<MorphoVault> | null | undefined): 
     return Array.isArray(val) ? val : [];
   };
 
+  // WELL rewards on Moonwell's Morpho vaults are distributed through the
+  // multi-reward staking distributor, which the SDK surfaces as `stakingRewards`
+  // / `stakingRewardsApr` — separate from the Morpho-native `rewards` /
+  // `rewardsApy`. Fold the staking rewards into the reward fields so consumers
+  // see the full reward APY (e.g. cbBTC's ~0.77% WELL rewards) instead of base
+  // APY only.
+  const stakingRewardsApr = toNumber(vault.stakingRewardsApr);
+
+  const rewards = [
+    ...toArray<Partial<MorphoReward>>(vault.rewards).map((reward) => ({
+      asset: serializeToken(reward.asset) || {
+        address: '', name: '', symbol: '', decimals: 0
+      },
+      supplyApr: toNumber(reward.supplyApr),
+      supplyAmount: toNumber(reward.supplyAmount),
+      borrowApr: toNumber(reward.borrowApr),
+      borrowAmount: toNumber(reward.borrowAmount)
+    })),
+    ...toArray<Partial<MorphoStakingReward>>(vault.stakingRewards).map((stakingReward) => ({
+      asset: serializeToken(stakingReward.token) || {
+        address: '', name: '', symbol: '', decimals: 0
+      },
+      supplyApr: toNumber(stakingReward.apr),
+      supplyAmount: 0,
+      borrowApr: 0,
+      borrowAmount: 0
+    }))
+  ];
+
   return {
     // Basic vault info
     vaultKey: vault.vaultKey || '',
@@ -72,10 +101,10 @@ export const serializeVault = (vault: Partial<MorphoVault> | null | undefined): 
     },
     underlyingPrice: toNumber(vault.underlyingPrice),
 
-    // APY info
+    // APY info (rewards/total include WELL staking rewards, see above)
     baseApy: toNumber(vault.baseApy),
-    totalApy: toNumber(vault.totalApy),
-    rewardsApy: toNumber(vault.rewardsApy),
+    totalApy: toNumber(vault.totalApy) + stakingRewardsApr,
+    rewardsApy: toNumber(vault.rewardsApy) + stakingRewardsApr,
 
     // Configuration
     curators: toArray(vault.curators),
@@ -112,15 +141,7 @@ export const serializeVault = (vault: Partial<MorphoVault> | null | undefined): 
       }))
     })),
 
-    // Rewards
-    rewards: (vault.rewards || []).map((reward: Partial<MorphoReward>) => ({
-      asset: serializeToken(reward.asset) || { 
-        address: '', name: '', symbol: '', decimals: 0
-      },
-      supplyApr: toNumber(reward.supplyApr),
-      supplyAmount: toNumber(reward.supplyAmount),
-      borrowApr: toNumber(reward.borrowApr),
-      borrowAmount: toNumber(reward.borrowAmount)
-    }))
+    // Rewards (Morpho-native rewards plus WELL staking rewards)
+    rewards
   };
 };

--- a/src/tests/serializers/vault.test.ts
+++ b/src/tests/serializers/vault.test.ts
@@ -128,6 +128,72 @@ describe('serializeVault', () => {
     expect(result).toEqual(expectedResult);
   });
 
+  it('should fold WELL staking rewards into rewards, rewardsApy and totalApy', () => {
+    // Regression for MOO-391: cbBTC WELL rewards are distributed via the
+    // multi-reward staking distributor, surfaced by the SDK as `stakingRewards`
+    // / `stakingRewardsApr`. They must be included so the API reports the full
+    // reward APY instead of base APY only.
+    const wellToken: TokenConfig = { ...mockToken, address: '0xWELL', symbol: 'WELL' };
+    const vault: Partial<MorphoVault> = {
+      vaultKey: 'CBBTC-VAULT',
+      vaultToken: mockToken,
+      underlyingToken: mockToken,
+      baseApy: 0.0192,
+      rewardsApy: 0,
+      totalApy: 0.0192,
+      rewards: [],
+      stakingRewardsApr: 0.77,
+      stakingRewards: [{ apr: 0.77, token: wellToken }]
+    };
+
+    const result = serializeVault(vault);
+    expect(result?.rewardsApy).toBeCloseTo(0.77);
+    expect(result?.totalApy).toBeCloseTo(0.7892);
+    expect(result?.baseApy).toBe(0.0192);
+    expect(result?.rewards).toEqual([{
+      asset: { address: '0xWELL', name: 'Test Token', symbol: 'WELL', decimals: 18 },
+      supplyApr: 0.77,
+      supplyAmount: 0,
+      borrowApr: 0,
+      borrowAmount: 0
+    }]);
+  });
+
+  it('should combine Morpho-native rewards with staking rewards', () => {
+    const wellToken: TokenConfig = { ...mockToken, address: '0xWELL', symbol: 'WELL' };
+    const vault: Partial<MorphoVault> = {
+      vaultKey: 'COMBINED-VAULT',
+      baseApy: 0.02,
+      rewardsApy: 0.01,
+      totalApy: 0.03,
+      rewards: [mockReward],
+      stakingRewardsApr: 0.05,
+      stakingRewards: [{ apr: 0.05, token: wellToken }]
+    };
+
+    const result = serializeVault(vault);
+    expect(result?.rewardsApy).toBeCloseTo(0.06);
+    expect(result?.totalApy).toBeCloseTo(0.08);
+    expect(result?.rewards).toHaveLength(2);
+    expect(result?.rewards[1].asset.symbol).toBe('WELL');
+    expect(result?.rewards[1].supplyApr).toBe(0.05);
+  });
+
+  it('should not change rewards when no staking rewards are present', () => {
+    const vault: Partial<MorphoVault> = {
+      vaultKey: 'NO-STAKING-VAULT',
+      baseApy: 0.03,
+      rewardsApy: 0.02,
+      totalApy: 0.05,
+      rewards: [mockReward]
+    };
+
+    const result = serializeVault(vault);
+    expect(result?.rewardsApy).toBe(0.02);
+    expect(result?.totalApy).toBe(0.05);
+    expect(result?.rewards).toHaveLength(1);
+  });
+
   it('should handle invalid numeric values', () => {
     const invalidVault: Partial<MorphoVault> = {
       vaultKey: 'TEST-VAULT',


### PR DESCRIPTION
## Summary

The yield API was returning `rewardsApy: 0` and an empty `rewards` array for the cbBTC vault (`0x76501E1C851286595d4B48437A0E1abDaf3fdc68`), so `totalApy` reflected base APY only and the product showed ~0.15% instead of the expected ~0.8%.

**Root cause:** WELL rewards on Moonwell's Morpho vaults are distributed through the multi-reward staking distributor. The SDK surfaces these as `stakingRewards` / `stakingRewardsApr`, which are deliberately kept separate from the Morpho-native `rewards` / `rewardsApy` / `totalApy`. The vault serializer (`src/serializers/vault.ts`) only read the Morpho-native fields and dropped the staking rewards entirely — for cbBTC the Morpho-native rewards are 0, so the WELL rewards (~0.77%) disappeared.

**Fix:** Fold the staking rewards into the serialized output:
- Append each `stakingReward` to the `rewards` array (mapped to the existing reward shape, with its `apr` as `supplyApr`).
- Add `stakingRewardsApr` to both `rewardsApy` and `totalApy`.

This keeps `serialized totalApy = baseApy + serialized rewardsApy` consistent, and is a no-op for vaults without staking rewards (`stakingRewardsApr` defaults to 0, `stakingRewards` defaults to `[]`).

## Test evidence

Added three regression tests in `src/tests/serializers/vault.test.ts` (staking-only cbBTC scenario, combined Morpho + staking rewards, and the no-staking no-op case). Full suite:

```
npx vitest run -c vitest.config.mts
Test Files  4 passed (4)
     Tests  25 passed (25)
```

All pre-existing tests continue to pass unchanged.

Fixes MOO-391

Linear: https://linear.app/moonwell/issue/MOO-391/yield-backend-isnt-returning-correct-rewards-for-cbbtc